### PR TITLE
demo alternative wrapping error implementation

### DIFF
--- a/src/errors2/errors.go
+++ b/src/errors2/errors.go
@@ -1,0 +1,15 @@
+package errors2
+
+// New is unchanged (go1.12.4)
+func New(text string) error {
+	return &errorString{text}
+}
+
+// errorString is a trivial implementation of error.
+type errorString struct {
+	s string
+}
+
+func (e *errorString) Error() string {
+	return e.s
+}

--- a/src/errors2/fmt.go
+++ b/src/errors2/fmt.go
@@ -1,0 +1,42 @@
+package errors2
+
+import (
+	"fmt"
+	"strings"
+)
+
+func isError(i interface{}) bool {
+	_, ok := i.(error)
+	return ok
+}
+
+const magicSuffix = ": %w"
+
+// Errorf should remain in package fmt. Placing it here for demo purposes only.
+// Mostly copied from go HEAD
+func Errorf(format string, a ...interface{}) error {
+	frame := Caller(1)
+
+	if len(a) == 0 || !isError(a[len(a)-1]) || !strings.HasSuffix(format, magicSuffix) {
+		return &WrappingError{
+			frame,
+			New(fmt.Sprintf(format, a...)),
+			nil,
+		}
+	}
+
+	err, ok := a[len(a)-1].(error)
+	if !ok {
+		return &WrappingError{
+			frame,
+			New(fmt.Sprintf(format, a...)),
+			nil,
+		}
+	}
+
+	return &WrappingError{
+		frame,
+		New(fmt.Sprintf(format[:len(format)-len(magicSuffix)], a[:len(a)-1]...)),
+		toWrappingError(err),
+	}
+}

--- a/src/errors2/formatter.go
+++ b/src/errors2/formatter.go
@@ -1,0 +1,102 @@
+package errors2
+
+import (
+	"bytes"
+)
+
+// Formatter defines how errors will be converted to a string.
+// They should be rare - most users will never have to create one.
+// They are stateful.
+type Formatter interface {
+	Init(*WrappingError)
+
+	Next() (error, Frame)
+
+	Format(error, Frame, *bytes.Buffer)
+}
+
+type inOrderPartialFormatter struct {
+	// final
+	formatFrames bool
+
+	// variable
+	firstEntry bool
+	currentErr *WrappingError
+}
+
+func (f *inOrderPartialFormatter) Init(wErr *WrappingError) {
+	f.currentErr = wErr
+	f.firstEntry = true
+}
+
+func (f *inOrderPartialFormatter) Next() (error, Frame) {
+	if f.currentErr == nil {
+		return nil, Frame{}
+	}
+	payload := f.currentErr.payload
+	frame := f.currentErr.frame
+	f.currentErr = f.currentErr.next
+	return payload, frame
+}
+
+type colonFormatter struct {
+	inOrderPartialFormatter
+}
+
+func (s *colonFormatter) Format(err error, frame Frame, buf *bytes.Buffer) {
+	if s.firstEntry {
+		s.firstEntry = false
+	} else {
+		buf.WriteString(": ")
+	}
+
+	if bufErr, ok := err.(BufferError); ok {
+		bufErr.ErrorToBuffer(buf)
+	} else {
+		buf.WriteString(err.Error())
+	}
+
+	if s.formatFrames && !frame.isVoid {
+		buf.WriteString(" (")
+		frame.Format(buf)
+		buf.WriteString(")")
+	}
+}
+
+// NewColonFormatter provides a formatter that appends messages with ': '.
+// It is the Formatter used by the %s representation of errors.
+func NewColonFormatter(formatFrames bool) Formatter {
+	return &colonFormatter{inOrderPartialFormatter: inOrderPartialFormatter{formatFrames: formatFrames}}
+}
+
+var (
+	defaultShortStringer = NewStringer(func() Formatter { return NewColonFormatter(false) })
+)
+
+type multiLineFormatter struct {
+	inOrderPartialFormatter
+}
+
+func (s *multiLineFormatter) Format(err error, frame Frame, buf *bytes.Buffer) {
+	if s.firstEntry {
+		s.firstEntry = false
+	} else {
+		buf.WriteString("\n")
+	}
+
+	if bufErr, ok := err.(BufferError); ok {
+		bufErr.ErrorToBuffer(buf)
+	} else {
+		buf.WriteString(err.Error())
+	}
+
+	if s.formatFrames && !frame.isVoid {
+		buf.WriteString("\n\t")
+		frame.Format(buf)
+	}
+}
+
+// NewColonFormatter provides a formatter that appends messages with '\n'.
+func NewMultiLineFormatter(formatFrames bool) Formatter {
+	return &multiLineFormatter{inOrderPartialFormatter: inOrderPartialFormatter{formatFrames: formatFrames}}
+}

--- a/src/errors2/frame.go
+++ b/src/errors2/frame.go
@@ -1,0 +1,54 @@
+package errors2
+
+import (
+	"bytes"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// A Frame contains part of a call stack.
+type Frame struct {
+	isVoid bool
+	frames [1]uintptr
+}
+
+// Caller returns a Frame that describes a frame on the caller's stack.
+// The argument skip is the number of frames to skip over.
+// Caller(0) returns the frame for the caller of Caller.
+func Caller(skip int) Frame {
+	var s Frame
+	runtime.Callers(skip+2, s.frames[:])
+	return s
+}
+
+// location reports the file, line, and function of a frame.
+//
+// The returned function may be "" even if file and line are not.
+func (f Frame) data() (function, file string, line int) {
+	frames := runtime.CallersFrames(f.frames[:])
+	fr, _ := frames.Next()
+	return fr.Function, fr.File, fr.Line
+}
+
+func shortened(s string) string {
+	if i := strings.LastIndex(s, "/"); i != -1 {
+		return s[i+1:]
+	}
+	return s
+}
+
+func (f Frame) Format(buf *bytes.Buffer) {
+	function, file, line := f.data()
+	if function != "" {
+		buf.WriteString(shortened(function))
+	}
+	if function != "" && file != "" {
+		buf.WriteString(":")
+	}
+	if file != "" {
+		buf.WriteString(shortened(file))
+		buf.WriteString(":")
+		buf.WriteString(strconv.Itoa(line))
+	}
+}

--- a/src/errors2/stringer.go
+++ b/src/errors2/stringer.go
@@ -1,0 +1,64 @@
+package errors2
+
+import (
+	"bytes"
+	"sync"
+)
+
+func NewStringer(fFactory func() Formatter) *Stringer {
+	return &Stringer{
+		pool: sync.Pool{
+			New: func() interface{} {
+				return &stringerPoolData{
+					f: fFactory(),
+				}
+			},
+		},
+	}
+}
+
+type stringerPoolData struct {
+	f   Formatter
+	buf bytes.Buffer
+}
+
+// Stringer is a thin wrapper around a Formatter factory that converts any wrapped error to its string format.
+type Stringer struct {
+	pool sync.Pool
+}
+
+func (s *Stringer) String(err error) string {
+	pd := s.pool.Get().(*stringerPoolData)
+
+	s.toBuffer(pd.f, err, &pd.buf)
+
+	out := pd.buf.String()
+
+	pd.buf.Reset()
+	s.pool.Put(pd)
+
+	return out
+}
+
+func (s *Stringer) toBuffer(f Formatter, err error, buf *bytes.Buffer) {
+	wErr, ok := err.(*WrappingError)
+	if !ok {
+		wErr = &WrappingError{
+			payload: err,
+		}
+	}
+
+	f.Init(wErr)
+
+	for err, frame := f.Next(); err != nil; err, frame = f.Next() {
+		f.Format(err, frame, buf)
+	}
+}
+
+// BufferError is an optional interface that errors may implement for efficiency purposes.
+// If an error's Error() method results in a string allocation for the return statement, it would benefit from this.
+type BufferError interface {
+	// ErrorToBuffer is a buffering equivalent to Error().
+	// The same string as is returned by Error() is to be written to the buffer.
+	ErrorToBuffer(*bytes.Buffer)
+}

--- a/src/errors2/wrap.go
+++ b/src/errors2/wrap.go
@@ -1,0 +1,75 @@
+package errors2
+
+// WrappingError provides the error wrapping functionality, and is exclusively the only error type doing so.
+// Each WrappingError holds a (non-WrappingError, non-nil) error as the payload, and points to the next WrappingError.
+// The causal error (lowest in the wrapping chain) points to nil.
+type WrappingError struct {
+	frame   Frame
+	payload error
+	next    *WrappingError
+}
+
+// Error serializes the target according to the default colon serializer, omitting frames and joining with ": ".
+// For example, for "wrapper-2" -> "wrapper-1" -> StackError -> "cause" the result would be:
+// "wrapper-2: wrapper-1: cause"
+func (wErr *WrappingError) Error() string {
+	return defaultShortStringer.String(wErr)
+}
+
+// Payload is a getter to payload error.
+// It is non-nil and never a WrappingError.
+func (wErr *WrappingError) Payload() error {
+	return wErr.payload
+}
+
+// Next is a getter for the next WrappingError in the chain.
+// It returns nil for the last error in the chain.
+func (wErr *WrappingError) Next() *WrappingError {
+	return wErr.next
+}
+
+func toWrappingError(err error) *WrappingError {
+	wErr, ok := err.(*WrappingError)
+	if !ok {
+		return &WrappingError{
+			Frame{isVoid: true},
+			err,
+			nil,
+		}
+	}
+	return wErr
+}
+
+func SkipWrap(previous, wrap error, skip int) error {
+	if wrap == nil {
+		// avoid this
+		if previous == nil {
+			return nil
+		}
+		return toWrappingError(previous)
+	}
+
+	frame := Caller(skip + 1)
+
+	if previous == nil {
+		if wErr, ok := wrap.(*WrappingError); ok {
+			return wErr
+		}
+
+		return &WrappingError{
+			frame,
+			wrap,
+			nil,
+		}
+	}
+
+	return &WrappingError{
+		frame,
+		wrap,
+		toWrappingError(previous),
+	}
+}
+
+func Wrap(previous, wrap error) error {
+	return SkipWrap(previous, wrap, 1)
+}

--- a/src/errors2/wrap_bench_test.go
+++ b/src/errors2/wrap_bench_test.go
@@ -1,0 +1,127 @@
+package errors2_test
+
+import (
+	"errors"
+	"errors2"
+	"fmt"
+	"testing"
+)
+
+const (
+	alternative = "alternative"
+	proposal    = "proposal"
+)
+
+func benchmarkErrorf(b *testing.B, name string, f func(string, ...interface{}) error) {
+	b.Run(name, func(b *testing.B) {
+		scenarios := []struct {
+			name   string
+			format string
+			args   []interface{}
+		}{
+			{
+				"no_wrapping_const",
+				"hello world",
+				[]interface{}{},
+			},
+			{
+				"no_wrapping_formatted",
+				"hello %s",
+				[]interface{}{"world"},
+			},
+			{"single_wrapping",
+				"I wrap: %w",
+				[]interface{}{f("inner error")},
+			},
+		}
+
+		for _, scenario := range scenarios {
+			scenario := scenario
+
+			b.Run(scenario.name, func(b *testing.B) {
+				format := scenario.format
+				args := scenario.args
+
+				// b.Logf("output(N=%d): (len=%d) %q", b.N, len(f(format, args...).Error()), f(format, args...).Error()) // use for debugging
+				b.ResetTimer()
+
+				var err error
+				for n := 0; n < b.N; n++ {
+					err = f(format, args...)
+				}
+
+				// do not optimise the Errorf call away
+				_ = err
+			})
+		}
+	})
+}
+
+func BenchmarkErrorf(b *testing.B) {
+	benchmarkErrorf(b, alternative, errors2.Errorf)
+	benchmarkErrorf(b, proposal, fmt.Errorf)
+}
+
+func benchmarkErrorMethod(b *testing.B, name string, f func(uint8) error) {
+	b.Run(name, func(b *testing.B) {
+		scenarios := []struct {
+			name  string
+			wraps uint8
+		}{
+			{
+				"string_error_len_0",
+				0,
+			},
+			{
+				"string_error_len_1",
+				1,
+			},
+			{
+				"string_error_len_3",
+				3,
+			},
+			{
+				"string_error_len_10",
+				10,
+			},
+			{
+				"string_error_len_20",
+				20,
+			},
+		}
+
+		for _, scenario := range scenarios {
+			err := f(scenario.wraps)
+			b.Run(scenario.name, func(b *testing.B) {
+				// b.Logf("output(N=%d): (len=%d) %q", b.N, len(wErr.Error()), wErr.Error()) // use for debugging
+				b.ResetTimer()
+
+				var msg string
+				for n := 0; n < b.N; n++ {
+					msg = err.Error()
+				}
+
+				// do not optimise the Error call away
+				_ = msg
+			})
+		}
+	})
+}
+
+func BenchmarkErrorMethod(b *testing.B) {
+	benchmarkErrorMethod(b, alternative, func(wraps uint8) error {
+		err := errors2.New("cause")
+		for n := 0; n < int(wraps); n++ {
+			err = errors2.Errorf("wrapper_%d: %w", n, err)
+		}
+		return err
+	})
+
+	benchmarkErrorMethod(b, proposal, func(wraps uint8) error {
+		err := errors.New("cause")
+		for n := 0; n < int(wraps); n++ {
+			err = fmt.Errorf("wrapper_%d: %w", n, err)
+		}
+		return err
+	})
+}

--- a/src/errors2/wrap_test.go
+++ b/src/errors2/wrap_test.go
@@ -1,0 +1,123 @@
+package errors2_test
+
+import (
+	"errors2"
+	"testing"
+)
+
+func TestErrorf(t *testing.T) {
+	testStringAll(
+		t,
+		"no_wrapping",
+		errors2.Errorf(
+			"hello %s",
+			"world",
+		),
+		"hello world",
+		"hello world (errors2_test.TestErrorf:wrap_test.go:12)",
+		"hello world",
+		"hello world"+"\n\t"+"errors2_test.TestErrorf:wrap_test.go:12",
+	)
+
+	testStringAll(
+		t,
+		"single_wrapping",
+		errors2.Errorf(
+			"I wrap: %w",
+			errors2.New("inner error"),
+		),
+		"I wrap: inner error",
+		"I wrap (errors2_test.TestErrorf:wrap_test.go:25): inner error",
+		"I wrap"+"\n"+"inner error",
+		"I wrap"+"\n\t"+"errors2_test.TestErrorf:wrap_test.go:25"+"\n"+"inner error",
+	)
+}
+
+func TestWrap(t *testing.T) {
+	testStringAll(
+		t,
+		"nil_wrapping",
+		errors2.Wrap(
+			nil,
+			errors2.New("hello world"),
+		),
+		"hello world",
+		"hello world (errors2_test.TestWrap:wrap_test.go:40)",
+		"hello world",
+		"hello world"+"\n\t"+"errors2_test.TestWrap:wrap_test.go:40",
+	)
+
+	testStringAll(
+		t,
+		"single_wrapping",
+		errors2.Wrap(
+			errors2.New("inner error"),
+			errors2.New("I wrap"),
+		),
+		"I wrap: inner error",
+		"I wrap (errors2_test.TestWrap:wrap_test.go:53): inner error",
+		"I wrap"+"\n"+"inner error",
+		"I wrap"+"\n\t"+"errors2_test.TestWrap:wrap_test.go:53"+"\n"+"inner error",
+	)
+
+	testStringAll(
+		t,
+		"custom_error_wraps",
+		errors2.Wrap(
+			errors2.New("inner error"),
+			myError{},
+		),
+		"custom error type: inner error",
+		"custom error type (errors2_test.TestWrap:wrap_test.go:66): inner error",
+		"custom error type"+"\n"+"inner error",
+		"custom error type"+"\n\t"+"errors2_test.TestWrap:wrap_test.go:66"+"\n"+"inner error",
+	)
+
+	testStringAll(
+		t,
+		"custom_error_wrapped",
+		errors2.Wrap(
+			myError{},
+			errors2.New("I wrap"),
+		),
+		"I wrap: custom error type",
+		"I wrap (errors2_test.TestWrap:wrap_test.go:79): custom error type",
+		"I wrap"+"\n"+"custom error type",
+		"I wrap"+"\n\t"+"errors2_test.TestWrap:wrap_test.go:79"+"\n"+"custom error type",
+	)
+}
+
+type myError struct{}
+
+func (myError) Error() string { return "custom error type" }
+
+func testStringAll(
+	t *testing.T,
+	name string,
+	err error,
+	expectedDefault, expectedColonLong, expectedMultiLine, expectedMultiLineLong string) {
+	colonLongStringer := errors2.NewStringer(
+		func() errors2.Formatter { return errors2.NewColonFormatter(true) },
+	)
+	multiLineStringer := errors2.NewStringer(
+		func() errors2.Formatter { return errors2.NewMultiLineFormatter(false) },
+	)
+	multiLineLongStringer := errors2.NewStringer(
+		func() errors2.Formatter { return errors2.NewMultiLineFormatter(true) },
+	)
+
+	t.Run(name, func(t *testing.T) {
+		testStringSingle(t, "Error_method", err.Error(), expectedDefault)
+		testStringSingle(t, "colon_long", colonLongStringer.String(err), expectedColonLong)
+		testStringSingle(t, "multi_line", multiLineStringer.String(err), expectedMultiLine)
+		testStringSingle(t, "multi_line_long", multiLineLongStringer.String(err), expectedMultiLineLong)
+	})
+}
+
+func testStringSingle(t *testing.T, name string, got, expected string) {
+	t.Run(name, func(t *testing.T) {
+		if got != expected {
+			t.Fatalf("expected %q got %q", expected, got)
+		}
+	})
+}


### PR DESCRIPTION
## **NOT TO BE MERGED INTO golang/go**
### This is just a demo for use in https://github.com/golang/go/issues/29934 (*proposal: Go 2 error values*).

This shows (through a demo-only package, errors2) how `WrappingError`, as an **interface** (as per current proposal), is both less efficient and harder to use than a `WrappingError` as a **struct**.

Using `go version devel +59ea685ce9 Fri May 3 20:08:33 2019 +0000 darwin/amd64`

`go test ./... -bench=. -benchmem # with some formatting for easier comparison`
```
goos: darwin
goarch: amd64
pkg: errors2

# -- Errorf comparison. alternative (this) and proposal (official) largely identical

BenchmarkErrorf/alternative/no_wrapping_const-8                  2848824               413 ns/op              80 B/op          3 allocs/op
BenchmarkErrorf/proposal/no_wrapping_const-8                     2429305               481 ns/op              64 B/op          2 allocs/op

BenchmarkErrorf/alternative/no_wrapping_formatted-8              2651264               457 ns/op              80 B/op          3 allocs/op
BenchmarkErrorf/proposal/no_wrapping_formatted-8                 2363103               507 ns/op              64 B/op          2 allocs/op

BenchmarkErrorf/alternative/single_wrapping-8                    2556076               447 ns/op              72 B/op          3 allocs/op
BenchmarkErrorf/proposal/single_wrapping-8                       2905756               410 ns/op              56 B/op          2 allocs/op

# -- Error() comparison. alternative (this) massively outperforms proposal (official)

BenchmarkErrorMethod/alternative/string_error_len_0-8           695560956                1.65 ns/op            0 B/op          0 allocs/op
BenchmarkErrorMethod/proposal/string_error_len_0-8              468847897                2.52 ns/op            0 B/op          0 allocs/op

BenchmarkErrorMethod/alternative/string_error_len_1-8           11517566                99.0 ns/op            16 B/op          1 allocs/op
BenchmarkErrorMethod/proposal/string_error_len_1-8               2866568               416 ns/op              80 B/op          5 allocs/op

BenchmarkErrorMethod/alternative/string_error_len_3-8            7472667               161 ns/op              48 B/op          1 allocs/op
BenchmarkErrorMethod/proposal/string_error_len_3-8               1743448               682 ns/op             176 B/op          9 allocs/op

BenchmarkErrorMethod/alternative/string_error_len_10-8           3141358               375 ns/op             128 B/op          1 allocs/op
BenchmarkErrorMethod/proposal/string_error_len_10-8               757939              1534 ns/op             480 B/op         23 allocs/op

BenchmarkErrorMethod/alternative/string_error_len_20-8           1798628               666 ns/op             240 B/op          1 allocs/op
BenchmarkErrorMethod/proposal/string_error_len_20-8               431370              2809 ns/op             912 B/op         43 allocs/op
```
Note the above is using go master branch from April 30 as the current master has had almost all wrapping error code remove and a meaningful comparison is no longer possible.